### PR TITLE
Update to linstor-client-1.19.0

### DIFF
--- a/SOURCES/linstor-client-1.19.0.tar.gz
+++ b/SOURCES/linstor-client-1.19.0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d3aa0e7ca0d6bb87a91dd5aacec665f1ea05b3dc1bb2f35de7a243de2258607
+size 144443

--- a/SPECS/linstor-client.spec
+++ b/SPECS/linstor-client.spec
@@ -1,0 +1,43 @@
+Summary: DRBD distributed resource management utility
+Name:    linstor-client
+Version: 1.19.0
+Release: 1%{?dist}
+License: GPLv3
+URL:     https://linbit.com/linstor/
+
+BuildArch: noarch
+
+Source0: https://pkg.linbit.com//downloads/linstor/%{name}-%{version}.tar.gz
+
+%define python3_installed %(which python3 2>/dev/null)
+
+# The build container for XCP-ng 8.2 doesn't have python3, so python3 available
+# means we're building for XCP-ng 8.3 and use python3, python2 otherwise
+%if "%(which python3 2>/dev/null)"
+%define python "python3"
+BuildRequires: python3-setuptools
+%else
+%define python "python2"
+BuildRequires: python-setuptools
+%endif
+
+Requires: python-linstor >= 1.19.0
+
+%description
+This client program communicates to controller node which manages the resources
+
+%prep
+%autosetup -p1
+
+%build
+PYTHON=%{python} %{python} ./setup.py build
+
+%install
+PYTHON=%{python} %{python} ./setup.py install --single-version-externally-managed -O1 --root=$RPM_BUILD_ROOT --record=INSTALLED_FILES
+
+%files -f INSTALLED_FILES
+%license COPYING
+
+%changelog
+* Tue Nov 7 2023 Thierry Escande <thierry.escande@vates.tech> - 1.19.0-1
+- Update to linstor-client-1.19.0


### PR DESCRIPTION
This adds source archive and spec file for linstor-client v1.19.0.

The spec file targets both xcp-ng 8.2 and 8.3, using python 2 and python 3 respectively. In order to build the package using python 3 for xcp-ng 8.3, the spec file relies on the presence of the python3 executable which is only present in the xcp-ng 8.3 build container. The python 2 version for xcp-ng 8.2 is built otherwise.