### PR TITLE
8.2: Update to linstor-client-1.19.0

### DIFF
--- a/SOURCES/linstor-client-1.19.0.tar.gz
+++ b/SOURCES/linstor-client-1.19.0.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:6d3aa0e7ca0d6bb87a91dd5aacec665f1ea05b3dc1bb2f35de7a243de2258607
+size 144443

--- a/SPECS/linstor-client.spec
+++ b/SPECS/linstor-client.spec
@@ -1,0 +1,35 @@
+Summary: DRBD distributed resource management utility
+Name:    linstor-client
+Version: 1.19.0
+Release: 1%{?dist}
+License: GPL-3.0-or-later
+URL:     https://linbit.com/linstor/
+
+BuildArch: noarch
+BuildRequires: python-devel
+BuildRequires: python-setuptools
+
+Requires: python-linstor >= %{version}
+
+Source0: https://pkg.linbit.com/downloads/linstor/%{name}-%{version}.tar.gz
+
+%description
+This client program communicates to controller node which manages the resources
+
+%prep
+%autosetup -p1
+
+%build
+PYTHON=%{__python2} %{__python2} ./setup.py build
+
+%install
+PYTHON=%{__python2} %{__python2} ./setup.py install --single-version-externally-managed -O1 --root=$RPM_BUILD_ROOT --record=INSTALLED_FILES
+
+%files -f INSTALLED_FILES
+
+%license COPYING
+%doc README.md
+
+%changelog
+* Tue Nov 07 2023 Thierry Escande <thierry.escande@vates.tech> - 1.19.0-1
+- Update to linstor-client-1.19.0


### PR DESCRIPTION
This commit adds source archive and spec file for linstor-client v1.19.0. The package is built using python 2 and targets xcp-ng 8.2.